### PR TITLE
Added tests for DatabaseFileLookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Importer/Exporter for CFF format now supports JabRef `cites` and `related` relationships, as well as all fields from the CFF specification. [#10993](https://github.com/JabRef/jabref/issues/10993)
 - The XMP-Exporter no longer writes the content of the `file`-field. [#11083](https://github.com/JabRef/jabref/pull/11083)
 - We added notes, checks and warnings for the case of selection of non-empty directories while starting a new Systematic Literature Review. [#600](https://github.com/koppor/jabref/issues/600)
+- We added test cases for DatabaseFileLookup to cover file presence and absence scenarios. [koppor#678](https://github.com/koppor/jabref/issues/678)
 
 ### Fixed
 

--- a/src/test/java/org/jabref/logic/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/org/jabref/logic/importer/DatabaseFileLookupTest.java
@@ -3,17 +3,31 @@ package org.jabref.logic.importer;
 import java.util.Collection;
 
 import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.logic.util.io.DatabaseFileLookup;
 import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.util.DummyFileUpdateMonitor;
-
+import org.jabref.preferences.FilePreferences;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
 
 class DatabaseFileLookupTest {
 
@@ -25,7 +39,8 @@ class DatabaseFileLookupTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        ParserResult result = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor())
+        ParserResult result = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                new DummyFileUpdateMonitor())
                 .importDatabase(ImportDataTest.UNLINKED_FILES_TEST_BIB);
         database = result.getDatabase();
         entries = database.getEntries();
@@ -43,5 +58,53 @@ class DatabaseFileLookupTest {
         assertEquals(2, entries.size());
         assertNotNull(entry1);
         assertNotNull(entry2);
+    }
+
+    /**
+     * Tests the directory path functionality by creating a temporary file
+     * directory,
+     * creating a BibDatabaseContext with a BibDatabase containing two entries,
+     * setting the temporary directory as the default file directory in the
+     * preferences,
+     * and creating a DatabaseFileLookup instance.
+     *
+     * @param tempDir the temporary directory path
+     * @throws IOException if there is an error creating the temporary file
+     *                     directory
+     */
+    @Test
+    void directoryPathTests(@TempDir Path tempDir) throws IOException {
+        Path txtFileDir = tempDir.resolve("x.txt"); // Create a temporary directory for testing
+
+        try {
+            Files.write(txtFileDir, Collections.singleton("x.txt file contents for test"));
+        } catch (IOException e) {
+            fail("Failed to create temporary file directory: " + e.getMessage());
+        }
+
+        // Create a BibDatabaseContext with a BibDatabase containing two entries
+        BibDatabase bibDatabase = new BibDatabase();
+        BibEntry entry1 = new BibEntry();
+        entry1.setField(StandardField.FILE, txtFileDir.toAbsolutePath().toString());
+        BibEntry entry2 = new BibEntry();
+        entry2.setField(StandardField.FILE, "");
+        bibDatabase.insertEntry(entry1);
+        bibDatabase.insertEntry(entry2);
+
+        BibDatabaseContext databaseContext = new BibDatabaseContext(bibDatabase);
+
+        // Set the temporary directory as the default file directory
+        // in the preferences and creating DatabaseFileLookup instance
+        FilePreferences filePreferences = new FilePreferences("", txtFileDir.toAbsolutePath().toString(), false, "", "",
+                false, false, null, Collections.emptySet(), false, null);
+        DatabaseFileLookup fileLookup = new DatabaseFileLookup(databaseContext, filePreferences);
+
+        // Tests
+        assertTrue(fileLookup.lookupDatabase(txtFileDir)); // x.txt should be found
+        assertFalse(fileLookup.lookupDatabase(tempDir.resolve("y.txt"))); // y.txt should not be found
+        assertEquals(filePreferences.getMainFileDirectory().orElse(Path.of("")).toString(),
+                txtFileDir.toAbsolutePath().toString());
+        assertNotNull(fileLookup.getPathOfDatabase());
+        assertEquals("", fileLookup.getPathOfDatabase().toString());
     }
 }


### PR DESCRIPTION
I have added a new test case directoryPathTests to the DatabaseFileLookupTest class. This test case verifies the functionality of the DatabaseFileLookup class in handling file paths and directories. It creates a temporary directory and file, sets up a BibDatabaseContext with two entries (one with a valid file path and one with an empty file path), and configures the FilePreferences to use the temporary directory as the default file directory. Then, it creates an instance of DatabaseFileLookup and asserts that the file in the temporary directory is found, while a non-existent file is not found. The test case checks if the FilePreferences are correctly set up with the temporary directory as the main file directory, and if the getPathOfDatabase method of DatabaseFileLookup returns an empty path.

Closes https://github.com/koppor/jabref/issues/678

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
